### PR TITLE
🙋  Changing 'number' property to 'streetNumber'

### DIFF
--- a/frontend/functions/src/contacts.ts
+++ b/frontend/functions/src/contacts.ts
@@ -42,7 +42,7 @@ export const address = {
             type: 'string',
 			required: true
         },
-        number: {
+        streetNumber: {
             type: 'number',
 			required: true
         },


### PR DESCRIPTION
Hi! 🖖

I wasn't able to perform a POST on the `/contacts` endpoint because the `number` property on the `Address` model was different from the Readme instructions. 

Sending the PL to standardize the model accordingly with the Readme. 